### PR TITLE
fix: Fix program ignoring double spaces

### DIFF
--- a/Lectures/Lecture_22/Lecture_Codes/replace_spaces.cpp
+++ b/Lectures/Lecture_22/Lecture_Codes/replace_spaces.cpp
@@ -22,7 +22,7 @@ string replaceSpaces(string &str){
 //     for (int i = 0; i < str.length(); i++) {
 //         if (str[i] == ' ') {
 //             str.replace(i, 1, "@40");
-//             i += 3; // Move the index forward to skip the added characters
+//             i += 2; // Move the index forward to skip the added characters
 //         }
 //     }
 // }


### PR DESCRIPTION
Since the iterator `i` is being incremented by 3 it skips the next letter after the space as we only need to increment `i` by 2 as one incrementation is automatically done by the for loop

This will help fix the bug if a string with double spaces was provided to the program as input

> Input: 
> "Hello Ji  Kese Ho Sare"

> incrementing `i` by 3 output:
> Hello@40Ji@40 Kese@40Ho@40Sare

> incrementing `i` by 2 output:
> Hello@40Ji@40@40Kese@40Ho@40Sare

This is not a big change but i hope it will fix some people's doubt if anyone encountered it